### PR TITLE
Updates to .NET 9.0

### DIFF
--- a/src/MetarParserCore/MetarParserCore.csproj
+++ b/src/MetarParserCore/MetarParserCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Valery Borisov</Authors>
     <Owners>Valery Borisov</Owners>
@@ -14,7 +14,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
     <Version>1.1.0</Version>
-    <PackageTags>METAR, Parser, METAR Parser, Aviation Weather, .NET 6.0, .NET Core</PackageTags>
+    <PackageTags>METAR, Parser, METAR Parser, Aviation Weather, .NET 9.0, .NET Core</PackageTags>
     <PackageReleaseNotes>METAR parser</PackageReleaseNotes>
     <IsPublishable>False</IsPublishable>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/MetarParserCoreTests/MetarParserCoreTests.csproj
+++ b/src/MetarParserCoreTests/MetarParserCoreTests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
-    <PackageReference Include="xunit.core" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="xunit.assert" Version="2.9.3" />
+    <PackageReference Include="xunit.core" Version="2.9.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the currently used verion of .NET 6 to .NET 9 which is currently the latest version.

The Nuget packages have also been updated to the latest versions.

The unit tests are all green. There is 1 test that (before and after upgrading to .NET 9) sometimes fails (and sometimes passes) when running all tests at once: ParseMetarExampleUwkd_Successful
<img width="339" height="66" alt="afbeelding" src="https://github.com/user-attachments/assets/1313b10b-412a-4bf0-97b8-6770943cb0bd" />

Running the test itself in isolation always seems to pass. So perhaps some sort of race condition when running everything at once?

