### PR TITLE
Adds support for cloud layers and altimeter being unknown

### DIFF
--- a/src/MetarParserCore/Enums/ConvectiveCloudType.cs
+++ b/src/MetarParserCore/Enums/ConvectiveCloudType.cs
@@ -17,5 +17,12 @@ namespace MetarParserCore.Enums
 
         [Description("TCU")]
         ToweringCumulus = 2,
+        
+        /// <summary>
+        /// METAR station was unable to determine.
+        /// Example: FEW020///
+        /// </summary>
+        [Description("///")]
+        Unknown = 3
     }
 }

--- a/src/MetarParserCore/MetarParserCore.csproj
+++ b/src/MetarParserCore/MetarParserCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Valery Borisov</Authors>
     <Owners>Valery Borisov</Owners>
@@ -14,7 +14,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
     <Version>1.1.0</Version>
-    <PackageTags>METAR, Parser, METAR Parser, Aviation Weather, .NET 6.0, .NET Core</PackageTags>
+    <PackageTags>METAR, Parser, METAR Parser, Aviation Weather, .NET 9.0, .NET Core</PackageTags>
     <PackageReleaseNotes>METAR parser</PackageReleaseNotes>
     <IsPublishable>False</IsPublishable>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/MetarParserCore/Objects/AltimeterSetting.cs
+++ b/src/MetarParserCore/Objects/AltimeterSetting.cs
@@ -23,6 +23,12 @@ namespace MetarParserCore.Objects
         /// </summary>
         [DataMember(Name = "value", EmitDefaultValue = false)]
         public int Value { get; init; }
+        
+        /// <summary>
+        /// Is true when source metar has unknown pressure value.
+        /// Example: Q////
+        /// </summary>
+        public bool IsUnknown { get; set; }
 
         #region Constructors
 
@@ -42,7 +48,16 @@ namespace MetarParserCore.Objects
             var altimeterToken = tokens.First();
 
             UnitType = EnumTranslator.GetValueByDescription<AltimeterUnitType>(altimeterToken[..1]);
-            Value = int.Parse(altimeterToken[1..]);
+            
+            if (altimeterToken[1..].StartsWith("////"))
+            {
+                IsUnknown = true;
+            }
+            else
+            {
+                Value = int.Parse(altimeterToken[1..]);
+                IsUnknown = false;
+            }
         }
 
         #endregion

--- a/src/MetarParserCore/Objects/CloudLayer.cs
+++ b/src/MetarParserCore/Objects/CloudLayer.cs
@@ -110,7 +110,7 @@ namespace MetarParserCore.Objects
             if (token.StartsWith("///"))
             {
                 isCloudBelow = true;
-                return (0, token);
+                return (0, "");
             }
 
             if (!int.TryParse(token[..3], out var altitude))

--- a/src/MetarParserCore/TokenLogic/TokenRegex.cs
+++ b/src/MetarParserCore/TokenLogic/TokenRegex.cs
@@ -19,11 +19,11 @@
 
         public static string PresentWeather => @"^(-|\+|VC)?(BC|BL|DR|FZ|MI|PR|SH|TS)?(DZ|GR|GS|IC|PL|RA|SG|SN|UP|BR|DU|FG|FU|HZ|PY|SA|VA|DS|FC|PO|SQ|SS){1,3}$";
 
-        public static string CloudLayer => @"^((FEW|SCT|BKN|OVC|VV)\d{3}(CB|TCU)?|SKC|NSC|CLR|NCD)$";
+        public static string CloudLayer => @"^((FEW|SCT|BKN|OVC|VV)\d{3}(CB|TCU)?|SKC|NSC|CLR|NCD)(\/\/\/)?$";
 
         public static string Temperature => @"^M?\d{2}\/M?\d{2}$";
 
-        public static string AltimeterSetting => @"^(A|Q){1}\d{4}$";
+        public static string AltimeterSetting => @"^(A|Q)(\d{4}|\/\/\/\/)$";
 
         public static string Motne => @"^((R[0-3]{1}\d{1}\/|\d{2})([0-9\/]{1}[1259\/]{1}\d{4}|(CLRD|CLSD)\d{2})|R/SNOCLO|SNOCLO)$";
 

--- a/src/MetarParserCoreTests/AltimeterSettingTest.cs
+++ b/src/MetarParserCoreTests/AltimeterSettingTest.cs
@@ -16,7 +16,8 @@ namespace MetarParserCoreTests
             var tokens = new[]
             {
                 "A3012",
-                "Q1019"
+                "Q1019",
+                "Q////"
             };
 
             var errors = new List<string>();
@@ -24,7 +25,7 @@ namespace MetarParserCoreTests
                 .ToList();
 
             Assert.Equal(errors.Count, 0);
-            Assert.Equal(altimeterSettings.Count, 2);
+            Assert.Equal(altimeterSettings.Count, tokens.Length);
 
             #region Valid object
 
@@ -38,6 +39,11 @@ namespace MetarParserCoreTests
                 new AltimeterSetting
                 {
                     Value = 1019,
+                    UnitType = AltimeterUnitType.Hectopascal
+                },
+                new AltimeterSetting
+                {
+                    Value = 0,
                     UnitType = AltimeterUnitType.Hectopascal
                 }
             };

--- a/src/MetarParserCoreTests/CloudLayerTests.cs
+++ b/src/MetarParserCoreTests/CloudLayerTests.cs
@@ -21,6 +21,7 @@ namespace MetarParserCoreTests
                 "SCT025TCU",
                 "BKN100CB",
                 "OVC///",
+                "FEW020///",
                 "NSC"
             };
 
@@ -29,7 +30,7 @@ namespace MetarParserCoreTests
                 .ToList();
 
             Assert.Equal(errors.Count, 0);
-            Assert.Equal(cloudLayers.Count, 7);
+            Assert.Equal(cloudLayers.Count, tokens.Length);
 
             #region Valid object
 
@@ -66,6 +67,12 @@ namespace MetarParserCoreTests
                 {
                     CloudType = CloudType.Overcast,
                     IsCloudBelow = true
+                },
+                new CloudLayer
+                {
+                    CloudType = CloudType.Few,
+                    Altitude = 20,
+                    ConvectiveCloudType = ConvectiveCloudType.Unknown
                 },
                 new CloudLayer
                 {

--- a/src/MetarParserCoreTests/EntireMetarTests.cs
+++ b/src/MetarParserCoreTests/EntireMetarTests.cs
@@ -1,4 +1,5 @@
-﻿using MetarParserCore;
+﻿using System;
+using MetarParserCore;
 using MetarParserCore.Enums;
 using MetarParserCore.Objects;
 using MetarParserCore.Objects.Supplements;
@@ -49,8 +50,8 @@ namespace MetarParserCoreTests
                         MaxVisibilityDirection = VisibilityDirection.SouthEast
                     }
                 },
-                RunwayVisualRanges = new RunwayVisualRange[]
-                {
+                RunwayVisualRanges =
+                [
                     new RunwayVisualRange
                     {
                         RunwayNumber = "29",
@@ -58,27 +59,27 @@ namespace MetarParserCoreTests
                         UnitType = RvrUnitType.Meters,
                         RvrTrend = RvrTrend.Downward
                     }
-                },
-                PresentWeather = new WeatherPhenomena[]
-                {
+                ],
+                PresentWeather =
+                [
                     new WeatherPhenomena
                     {
-                        WeatherConditions = new WeatherCondition[]
-                        {
+                        WeatherConditions =
+                        [
                             WeatherCondition.Shower,
                             WeatherCondition.Rain
-                        }
+                        ]
                     }
-                },
-                CloudLayers = new CloudLayer[]
-                {
-                    new CloudLayer()
+                ],
+                CloudLayers =
+                [
+                    new CloudLayer
                     {
                         CloudType = CloudType.Broken,
                         Altitude = 15,
                         ConvectiveCloudType = ConvectiveCloudType.Cumulonimbus
                     }
-                },
+                ],
                 Temperature = new TemperatureInfo
                 {
                     Value = 17,
@@ -94,8 +95,8 @@ namespace MetarParserCoreTests
                     Runway = "29",
                     Type = WindShearType.TakeOff
                 },
-                Motne = new Motne[]
-                {
+                Motne =
+                [
                     new Motne
                     {
                         RunwayNumber = "29",
@@ -105,9 +106,9 @@ namespace MetarParserCoreTests
                         Specials = MotneSpecials.Default,
                         TypeOfDeposit = MotneTypeOfDeposit.Wet
                     }
-                },
-                Trends = new Trend[]
-                {
+                ],
+                Trends =
+                [
                     new Trend
                     {
                         ReportType = ReportType.Trend,
@@ -137,20 +138,20 @@ namespace MetarParserCoreTests
                             Speed = 15,
                             WindUnit = WindUnit.MetersPerSecond
                         },
-                        PresentWeather = new WeatherPhenomena[]
-                        {
+                        PresentWeather =
+                        [
                             new WeatherPhenomena
                             {
-                                WeatherConditions = new WeatherCondition[]
-                                {
+                                WeatherConditions =
+                                [
                                     WeatherCondition.Light,
                                     WeatherCondition.Thunderstorm,
                                     WeatherCondition.Rain
-                                }
+                                ]
                             }
-                        },
-                        CloudLayers = new CloudLayer[]
-                        {
+                        ],
+                        CloudLayers =
+                        [
                             new CloudLayer
                             {
                                 CloudType = CloudType.Broken,
@@ -162,9 +163,9 @@ namespace MetarParserCoreTests
                                 CloudType = CloudType.Overcast,
                                 Altitude = 110
                             }
-                        }
+                        ]
                     }
-                },
+                ],
                 Remarks = "QFE740/0987"
             };
 
@@ -226,24 +227,24 @@ namespace MetarParserCoreTests
                         Denominator = 2
                     }
                 },
-                PresentWeather = new WeatherPhenomena[]
-                {
+                PresentWeather =
+                [
                     new WeatherPhenomena
                     {
-                        WeatherConditions = new WeatherCondition[]
-                        {
+                        WeatherConditions =
+                        [
                             WeatherCondition.Haze
-                        }
+                        ]
                     }
-                },
-                CloudLayers = new CloudLayer[]
-                {
-                    new CloudLayer()
+                ],
+                CloudLayers =
+                [
+                    new CloudLayer
                     {
                         CloudType = CloudType.Overcast,
                         Altitude = 12
                     }
-                },
+                ],
                 Temperature = new TemperatureInfo
                 {
                     Value = 16,
@@ -255,6 +256,84 @@ namespace MetarParserCoreTests
                     UnitType = AltimeterUnitType.InchesOfMercury
                 },
                 Remarks = "AO2 SLP181 VIS SW-NW 1 3/4 T01560117 10156 20133 52006"
+            };
+
+            #endregion
+
+            var parseResults = JsonConvert.SerializeObject(airportMetar);
+            var validResults = JsonConvert.SerializeObject(validMetar);
+            Assert.Equal(parseResults, validResults);
+        }
+        
+        [Fact]
+        public void ParseMetarExampleEhmg_Successful()
+        {
+            var rawString = "METAR EHMG 111425Z AUTO 20027KT 9999 FEW005/// SCT009/// BKN010/// 12/11 Q////=";
+            var metarParser = new MetarParser();
+            var airportMetar = metarParser.Parse(rawString);
+
+            Assert.Null(airportMetar.ParseErrors);
+
+            #region Valid object
+
+            var validMetar = new Metar
+            {
+                ReportType = ReportType.Metar,
+                Modifier = MetarModifier.Auto,
+                Airport = "EHMG",
+                ObservationDayTime = new ObservationDayTime
+                {
+                    Day = 11,
+                    Time = new Time
+                    {
+                        Hours = 14,
+                        Minutes = 25
+                    }
+                },
+                SurfaceWind = new SurfaceWind
+                {
+                    Direction = 200,
+                    Speed = 27,
+                    WindUnit = WindUnit.Knots
+                },
+                PrevailingVisibility = new PrevailingVisibility
+                {
+                    VisibilityInMeters = new VisibilityInMeters
+                    {
+                        VisibilityValue = 9999
+                    }
+                },
+                CloudLayers =
+                [
+                    new CloudLayer
+                    {
+                        CloudType = CloudType.Few,
+                        Altitude = 5,
+                        ConvectiveCloudType = ConvectiveCloudType.Unknown
+                    },
+                    new CloudLayer
+                    {
+                        CloudType = CloudType.Scattered,
+                        Altitude = 9,
+                        ConvectiveCloudType = ConvectiveCloudType.Unknown
+                    },
+                    new CloudLayer
+                    {
+                        CloudType = CloudType.Broken,
+                        Altitude = 10,
+                        ConvectiveCloudType = ConvectiveCloudType.Unknown
+                    }
+                ],
+                Temperature = new TemperatureInfo
+                {
+                    Value = 12,
+                    DewPoint =11
+                },
+                AltimeterSetting = new AltimeterSetting
+                {
+                    UnitType = AltimeterUnitType.Hectopascal,
+                    IsUnknown = true
+                }
             };
 
             #endregion
@@ -302,13 +381,13 @@ namespace MetarParserCoreTests
                         VisibilityValue = 9999
                     }
                 },
-                CloudLayers = new CloudLayer[]
-                {
-                    new CloudLayer()
+                CloudLayers =
+                [
+                    new CloudLayer
                     {
                         CloudType = CloudType.NoCloudDetected
                     }
-                },
+                ],
                 Temperature = new TemperatureInfo
                 {
                     Value = 9,
@@ -319,14 +398,14 @@ namespace MetarParserCoreTests
                     Value = 1022,
                     UnitType = AltimeterUnitType.Hectopascal
                 },
-                Trends = new Trend[]
-                {
+                Trends =
+                [
                     new Trend
                     {
                         ReportType = ReportType.Trend,
                         TrendType = TrendType.NoSignificantChanges
                     }
-                }
+                ]
             };
 
             #endregion
@@ -377,28 +456,28 @@ namespace MetarParserCoreTests
                         Denominator = 4
                     }
                 },
-                PresentWeather = new WeatherPhenomena[]
-                {
+                PresentWeather =
+                [
                     new WeatherPhenomena
                     {
-                        WeatherConditions = new WeatherCondition[]
-                        {
+                        WeatherConditions =
+                        [
                             WeatherCondition.Mist
-                        }
+                        ]
                     }
-                },
-                CloudLayers = new CloudLayer[]
-                {
-                    new CloudLayer()
+                ],
+                CloudLayers =
+                [
+                    new CloudLayer
                     {
                         CloudType = CloudType.VerticalVisibility,
                         Altitude = 7
                     }
-                },
-                Unrecognized = new []
-                {
+                ],
+                Unrecognized =
+                [
                     "ERROR"
-                }
+                ]
             };
 
             #endregion

--- a/src/MetarParserCoreTests/MetarParserCoreTests.csproj
+++ b/src/MetarParserCoreTests/MetarParserCoreTests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
-    <PackageReference Include="xunit.core" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="xunit.assert" Version="2.9.3" />
+    <PackageReference Include="xunit.core" Version="2.9.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previous version was unable to parse the following METAR:
`METAR EHMG 111425Z AUTO 20027KT 9999 FEW005/// SCT009/// BKN010/// 12/11 Q////=`
Source: Netherlands KNMI

It would cause an exception. 

I'm not sure if this type of notation is a worldwide standard, but the the Netherlands Meteorology Institute seems to use this in their METAR reports.

**Warning:** I changed these file in a branch where I also upgraded the .NET version. Some of the changes may use a language feature that is not yet supported by .NET 6. If this PR is good to go, I suggest merging #10 first, and then this one.